### PR TITLE
#8 プロジェクト作成時に.gitignoreに本来記載しておくべきだった.eslintcacheが漏れていたので追記

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# add
+.eslintcache


### PR DESCRIPTION
# 目的
.gitignoreに.eslintcacheを追加する

# 達成条件
.gitignoreに.eslintcacheを追加

# 実装の概要
.gitignoreに.eslintcacheを追加した

# レビューして欲しいところ
mainにmergeするためにはPRを出す必要があるため、今回はPRを作成した。
新たに機能を追加したわけではないので、レビューしてほしいところはないです。

キャッシュを削除しないと反映されないので、
`git rm -r --cached .eslintcache`を実行してほしい。